### PR TITLE
add hostNetwork and dnsPolicy settings on jaeger's agent DaemonSet

### DIFF
--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -137,6 +137,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 |------------------------------------------|-------------------------------------|----------------------------------------|
 | `agent.annotations`                      | Annotations for Agent               |  nil                                   |
 | `agent.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
+| `agent.dnsPolicy`                        | configure DNS policy for agents     |  ClusterFirst                          |
 | `agent.image`                            | Image for Jaeger Agent              |  jaegertracing/jaeger-agent            |
 | `agent.pullPolicy`                       | Agent image pullPolicy              |  IfNotPresent                          |
 | `agent.tag`                              | Image tag/version                   |  0.6                                   |
@@ -144,6 +145,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `agent.service.binaryPort`               | jaeger.thrift over binary thrift    |  6832                                  |
 | `agent.service.compactPort`              | jaeger.thrift over compact thrift   |  6831                                  |
 | `agent.service.zipkinThriftPort`         | zipkin.thrift over compact thrift   |  5775                                  |
+| `agent.useHostNetwork`                   | enable hostNetwork for agents       |  false                                 |
 | `cassandra.config.cluster_name`          | Cluster name                        |  jaeger                                |
 | `cassandra.config.dc_name`               | Datacenter name                     |  dc1                                   |
 | `cassandra.config.endpoint_snitch`       | Node discovery method               |  GossipingPropertyFileSnitch           |

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -26,6 +26,10 @@ spec:
 {{ toYaml .Values.agent.podLabels | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.agent.useHostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      dnsPolicy: {{ .Values.agent.dnsPolicy }}
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}
       containers:

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -107,6 +107,8 @@ agent:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  useHostNetwork: false
+  dnsPolicy: ClusterFirst
 
 collector:
   enabled: true


### PR DESCRIPTION
We want to allow processes to use a daemon on the local host. We don't need to go through DNS for that, and we don't do so for other similar deployments. To enable the jaeger agent to have a port on the host, we set hostNetwork. This causes a different DNS configuration for the agent, which needs to be able to find its jaeger-collector. The remedy for this is to set dnsPolicy to ClusterFirstWithHostNet (this is documented on the web).