### PR TITLE
require opt-in to admin user creation

### DIFF
--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -48,8 +48,9 @@ Parameter | Description | Default
 `keycloak.image.tag` | The Keycloak image tag | `4.1.0.Final`
 `keycloak.image.pullPolicy` | The Keycloak image pull policy | `IfNotPresent`
 `keycloak.image.pullSecrets` | Image pull secrets | `[]`
-`keycloak.username` | Username for the initial Keycloak admin user | `keycloak`
-`keycloak.password` | Password for the initial Keycloak admin user. If not set, a random 10 characters password is created | `""`
+`keycloak.admin.create` | Whether this chart should generate an initial Keycloak admin user | `true`
+`keycloak.admin.username` | Username for the initial Keycloak admin user | `keycloak`
+`keycloak.admin.password` | Password for the initial Keycloak admin user. If not set, a random 10 characters password is created | `""`
 `keycloak.extraInitContainers` | Additional init containers, e. g. for providing themes, etc. Passed through the `tpl` funtion and thus to be configured a string | `""`
 `keycloak.extraContainers` | Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy. Passed through the `tpl` funtion and thus to be configured a string | `""`
 `keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. Passed through the `tpl` funtion and thus to be configured a string | `""`

--- a/stable/keycloak/templates/NOTES.txt
+++ b/stable/keycloak/templates/NOTES.txt
@@ -42,10 +42,10 @@ Keycloak can be accessed:
 
 {{- end }}
 
-{{- if .Release.IsInstall }}
+{{- if and .Release.IsInstall .Values.keycloak.admin.create }}
 
 Login with the following credentials:
-Username: {{ .Values.keycloak.username }}
+Username: {{ .Values.keycloak.admin.username }}
 
 To retrieve the initial user password run:
 kubectl get secret --namespace {{ .Release.Namespace }} {{ template "keycloak.fullname" . }}-http -o jsonpath="{.data.password}" | base64 --decode; echo

--- a/stable/keycloak/templates/keycloak-secret.yaml
+++ b/stable/keycloak/templates/keycloak-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.keycloak.admin.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,8 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-{{- if .Values.keycloak.password }}
-  password: {{ .Values.keycloak.password | b64enc | quote }}
+{{- if .Values.keycloak.admin.password }}
+  password: {{ .Values.keycloak.admin.password | b64enc | quote }}
 {{- else }}
   password: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end }}
+{{- end -}}

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -54,9 +54,9 @@ spec:
           command:
             - /scripts/keycloak.sh
           env:
-          {{- if .Release.IsInstall }}
+          {{- if and .Release.IsInstall .Values.keycloak.admin.create }}
             - name: KEYCLOAK_USER
-              value: {{ .Values.keycloak.username }}
+              value: {{ .Values.keycloak.admin.username }}
             - name: KEYCLOAK_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -36,8 +36,10 @@ keycloak:
   ## Additional arguments to start command e.g. -Dkeycloak.import= to load a realm
   extraArgs: ""
 
-  ## Username for the initial Keycloak admin user
-  username: keycloak
+  ## Config for the initial Keycloak admin user
+  admin:
+    create: true
+    username: keycloak
 
   ## Password for the initial Keycloak admin user
   ## If not set, a random 10 characters password will be used


### PR DESCRIPTION
Issue: with the chart as-is, installing the chart may create an unexpected admin user, which anyone with access to kubernetes secrets can obtain the password for.

This PR disables that functionality unless `keycloak.admin.create` is set to `true`