### PR TITLE
Expose HTTPS port instead of HTTP for internal traffic [PLAT-1176]

### DIFF
--- a/stable/keycloak/templates/NOTES.txt
+++ b/stable/keycloak/templates/NOTES.txt
@@ -3,7 +3,7 @@ Keycloak can be accessed:
 
 * Within your cluster, at the following DNS name at port {{ .Values.keycloak.service.port }}:
 
-  {{ template "keycloak.fullname" . }}-http.{{ .Release.Namespace }}.svc.cluster.local
+  {{ template "keycloak.fullname" . }}-https.{{ .Release.Namespace }}.svc.cluster.local
 
 {{- if .Values.keycloak.ingress.enabled }}
 
@@ -21,7 +21,7 @@ Keycloak can be accessed:
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "keycloak.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo https://$NODE_IP:$NODE_PORT
 
 {{- else if contains "LoadBalancer" .Values.keycloak.service.type }}
 
@@ -30,12 +30,12 @@ Keycloak can be accessed:
   You can watch the status of by running 'kubectl get svc -w {{ template "keycloak.fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "keycloak.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.keycloak.service.port }}
+  echo https://$SERVICE_IP:{{ .Values.keycloak.service.port }}
 
 {{- else if contains "ClusterIP" .Values.keycloak.service.type }}
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "keycloak.name" . }},release={{ .Release.Name }} -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use Keycloak"
+  echo "Visit https://127.0.0.1:8080 to use Keycloak"
   kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080
 
 {{- end }}
@@ -48,5 +48,5 @@ Login with the following credentials:
 Username: {{ .Values.keycloak.username }}
 
 To retrieve the initial user password run:
-kubectl get secret --namespace {{ .Release.Namespace }} {{ template "keycloak.fullname" . }}-http -o jsonpath="{.data.password}" | base64 --decode; echo
+kubectl get secret --namespace {{ .Release.Namespace }} {{ template "keycloak.fullname" . }}-https -o jsonpath="{.data.password}" | base64 --decode; echo
 {{- end }}

--- a/stable/keycloak/templates/headless-service.yaml
+++ b/stable/keycloak/templates/headless-service.yaml
@@ -11,9 +11,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: http
+    - name: https
       port: {{ .Values.keycloak.service.port }}
-      targetPort: http
+      targetPort: https
       protocol: TCP
   selector:
     app: {{ template "keycloak.name" . }}

--- a/stable/keycloak/templates/https-service.yaml
+++ b/stable/keycloak/templates/https-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "keycloak.fullname" . }}-http
+  name: {{ template "keycloak.fullname" . }}-https
 {{- with $service.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -18,9 +18,9 @@ metadata:
 spec:
   type: {{ $service.type }}
   ports:
-    - name: http
+    - name: https
       port: {{ $service.port }}
-      targetPort: http
+      targetPort: https
     {{- if and (eq "NodePort" $service.type) $service.nodePort }}
       nodePort: {{ $service.nodePort }}
     {{- end }}

--- a/stable/keycloak/templates/ingress.yaml
+++ b/stable/keycloak/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
         paths:
           - path: {{ $ingress.path }}
             backend:
-              serviceName: {{ template "keycloak.fullname" $ }}-http
-              servicePort: http
+              serviceName: {{ template "keycloak.fullname" $ }}-https
+              servicePort: https
   {{- end }}
 {{- end -}}

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -77,6 +77,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: https
+              containerPort: 8443
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /auth/

--- a/stable/keycloak/templates/test/test-configmap.yaml
+++ b/stable/keycloak/templates/test/test-configmap.yaml
@@ -19,7 +19,7 @@ data:
     print('Creating PhantomJS driver...')
     driver = webdriver.PhantomJS()
 
-    base_url = 'http://{{ template "keycloak.fullname" . }}-http{{ if ne 80 (int .Values.keycloak.service.port) }}{{ .Values.keycloak.service.port }}{{ end }}'
+    base_url = 'https://{{ template "keycloak.fullname" . }}-https{{ if ne 80 (int .Values.keycloak.service.port) }}{{ .Values.keycloak.service.port }}{{ end }}'
 
     print('Opening Keycloak...')
     driver.get('{0}/auth/admin/'.format(base_url))

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -181,7 +181,7 @@ keycloak:
     ## Optional static port assignment for service type NodePort.
     # nodePort: 30000
 
-    port: 80
+    port: 443
 
   ## Ingress configuration.
   ## ref: https://kubernetes.io/docs/user-guide/ingress/
@@ -189,7 +189,11 @@ keycloak:
     enabled: false
     path: /
 
-    annotations: {}
+    annotations:
+      #When using an nginx ingress, we need to configure the fact that we're communicating to an SSL port.
+      nginx.ingress.kubernetes.io/secure-backends: "true"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
       # ingress.kubernetes.io/affinity: cookie


### PR DESCRIPTION
[PLAT-1176]
Issues:
* Keycloak's 3rd-party integration works incorrectly when accessed over HTTP. (Redirects to `http://`)
* Keycloak's default configuration denies login when accessed via HTTP
* Traffic from the ingress to Keycloak is in plaintext, and contains user credentials.

This sets `nginx.ingress.kubernetes.io/secure-backends`, and defines the service to use the HTTPS port instead of the HTTP port on the pod.

Without further configuration, Keycloak is just self-generating and self-signing a certificate, so it's not something the ingress can verify. Thus, this only marginally improves resistance to eavesdropping credentials. (See [PLAT-1177])

[PLAT-1176]: https://opendoor.atlassian.net/browse/PLAT-1176
[PLAT-1177]: https://opendoor.atlassian.net/browse/PLAT-1177