### PR TITLE
Send Concourse build logs to Splunk

### DIFF
--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -678,16 +678,6 @@ concourse:
       ##
       useCaCert: false
 
-    sidecarContainers:
-    - name: atc-syslog
-      image: splunk/scs
-      ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
-      env:
-      - name: SPLUNK_HEC_URL
-        value: https://http-inputs-opendoor.splunkcloud.com:443
-      - name: SPLUNK_HEC_TOKEN
-        value: od_secret:secret/kubernetes/concourse/concourse-web/splunk#hec_token
-
     auth:
       ## Force sending secure flag on http cookies
       ##
@@ -1302,7 +1292,15 @@ web:
   ##   image: busybox
   ##   command: ['sh', '-c', 'echo Hello && sleep 3600']
   ##
-  sidecarContainers: []
+  sidecarContainers:
+  - name: atc-syslog
+    image: splunk/scs
+    ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
+    env:
+    - name: SPLUNK_HEC_URL
+      value: https://http-inputs-opendoor.splunkcloud.com:443
+    - name: SPLUNK_HEC_TOKEN
+      value: od_secret:secret/kubernetes/concourse/concourse-web/splunk#hec_token
 
   ## Configures the liveness probe used to determine if the Web component is up.
   ## ps.: if you're upgrading Concourse from one version  to another, the probe will

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1295,6 +1295,9 @@ web:
   sidecarContainers:
   - name: atc-syslog
     image: splunk/scs
+    ## We must explicitly set a command for od-secret.
+    ## See https://github.com/opendoor-labs/od-secret/blob/master/README.md#important
+    command: ["/entrypoint.sh", "-F"]
     ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
     env:
     - name: SPLUNK_HEC_URL

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -655,7 +655,7 @@ concourse:
       ## Enables the emission of build logs to external log ingesters through
       ## using the syslog protocol.
       ##
-      enabled: false
+      enabled: true
 
       ## Client hostname with which the build logs will be sent to the syslog server.
       ##
@@ -663,11 +663,11 @@ concourse:
 
       ## Remote syslog server address with port (Example: 0.0.0.0:514).
       ##
-      address:
+      address: localhost:514
 
       ## Transport protocol for syslog messages (Currently supporting tcp, udp & tls).
       ##
-      transport:
+      transport: udp
 
       ## Interval over which checking is done for new build logs to send to syslog server
       ## (duration measurement units are s/m/h; eg. 30s/30m/1h)
@@ -677,6 +677,16 @@ concourse:
       ## and provide a value for the cert in secrets (`syslog-ca-cert`).
       ##
       useCaCert: false
+
+    sidecarContainers:
+    - name: atc-syslog
+      image: splunk/scs
+      ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
+      env:
+      - name: SPLUNK_HEC_URL
+        value: https://http-inputs-opendoor.splunkcloud.com:443  # Or get from vault
+      - name: SPLUNK_HEC_TOKEN
+        value: # TODO: get from vault
 
     auth:
       ## Force sending secure flag on http cookies

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -684,9 +684,9 @@ concourse:
       ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
       env:
       - name: SPLUNK_HEC_URL
-        value: https://http-inputs-opendoor.splunkcloud.com:443  # Or get from vault
+        value: https://http-inputs-opendoor.splunkcloud.com:443
       - name: SPLUNK_HEC_TOKEN
-        value: # TODO: get from vault
+        value: od_secret:concourse/engineering/concourse-web/splunk_hec_token#value
 
     auth:
       ## Force sending secure flag on http cookies

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1295,12 +1295,13 @@ web:
   sidecarContainers:
   - name: atc-syslog
     image: splunk/scs:v1.15.2
-    ## Set the index to concourse. Our token only has write access to this index.
+    ## Set the index to concourse by writing to a special file splunk_index.csv. Our token only has write access to this index.
     command:
     - bash
     - -c
     - |
-      echo sc4s_fallback,index,concourse >>/opt/syslog-ng/etc/context_templates/splunk_index.csv.example ;
+      mkdir -p /opt/syslog-ng/etc/conf.d/local/context/ ;
+      echo sc4s_fallback,index,concourse >/opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv ;
       /entrypoint.sh -F
     ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
     env:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1304,6 +1304,8 @@ web:
       value: https://http-inputs-opendoor.splunkcloud.com:443/services/collector/event
     - name: SPLUNK_HEC_TOKEN
       value: od_secret:secret/kubernetes/concourse/concourse-web/splunk#hec_token
+    - name: SC4S_DEST_GLOBAL_ALTERNATES  # FIXME: debugging, remove
+      value: d_hec_debug
 
   ## Configures the liveness probe used to determine if the Web component is up.
   ## ps.: if you're upgrading Concourse from one version  to another, the probe will

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1300,12 +1300,8 @@ web:
     - bash
     - -c
     - |
-      bash /entrypoint.sh -F &
-      PID=$! ;
-      echo sc4s_fallback,index,concourse >>/opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv ;
-      kill -SIGHUP $PID ;
-      trap : TERM INT ;
-      tail -f /dev/null & wait
+      echo sc4s_fallback,index,concourse >>/opt/syslog-ng/etc/context_templates/splunk_index.csv.example ;
+      /entrypoint.sh -F
     ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
     env:
     - name: SPLUNK_HEC_URL

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -667,7 +667,7 @@ concourse:
 
       ## Transport protocol for syslog messages (Currently supporting tcp, udp & tls).
       ##
-      transport: udp
+      transport: tcp
 
       ## Interval over which checking is done for new build logs to send to syslog server
       ## (duration measurement units are s/m/h; eg. 30s/30m/1h)
@@ -1301,7 +1301,7 @@ web:
     ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
     env:
     - name: SPLUNK_HEC_URL
-      value: https://http-inputs-opendoor.splunkcloud.com:443
+      value: https://http-inputs-opendoor.splunkcloud.com:443/services/collector/event
     - name: SPLUNK_HEC_TOKEN
       value: od_secret:secret/kubernetes/concourse/concourse-web/splunk#hec_token
 

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1294,18 +1294,25 @@ web:
   ##
   sidecarContainers:
   - name: atc-syslog
-    image: splunk/scs
+    image: splunk/scs:v1.15.2
     ## We must explicitly set a command for od-secret.
     ## See https://github.com/opendoor-labs/od-secret/blob/master/README.md#important
-    command: ["/entrypoint.sh", "-F"]
+    command:
+    - bash
+    - -c
+    - |
+      bash /entrypoint.sh -F &
+      PID=$!
+      # Set the index to concourse. Our token only has write access to this index.
+      echo sc4s_fallback,index,concourse >>/opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv
+      # Restart syslog
+      kill -SIGHUP $!
     ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
     env:
     - name: SPLUNK_HEC_URL
       value: https://http-inputs-opendoor.splunkcloud.com:443/services/collector/event
     - name: SPLUNK_HEC_TOKEN
       value: od_secret:secret/kubernetes/concourse/concourse-web/splunk#hec_token
-    - name: SC4S_DEST_GLOBAL_ALTERNATES  # FIXME: debugging, remove
-      value: d_hec_debug
 
   ## Configures the liveness probe used to determine if the Web component is up.
   ## ps.: if you're upgrading Concourse from one version  to another, the probe will

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1303,7 +1303,7 @@ web:
       bash /entrypoint.sh -F &
       PID=$! ;
       echo sc4s_fallback,index,concourse >>/opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv ;
-      kill -SIGHUP $!
+      kill -SIGHUP $PID
     ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
     env:
     - name: SPLUNK_HEC_URL

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1295,17 +1295,14 @@ web:
   sidecarContainers:
   - name: atc-syslog
     image: splunk/scs:v1.15.2
-    ## We must explicitly set a command for od-secret.
-    ## See https://github.com/opendoor-labs/od-secret/blob/master/README.md#important
+    ## Set the index to concourse. Our token only has write access to this index.
     command:
     - bash
     - -c
     - |
       bash /entrypoint.sh -F &
-      PID=$!
-      # Set the index to concourse. Our token only has write access to this index.
-      echo sc4s_fallback,index,concourse >>/opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv
-      # Restart syslog
+      PID=$! ;
+      echo sc4s_fallback,index,concourse >>/opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv ;
       kill -SIGHUP $!
     ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
     env:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1303,7 +1303,9 @@ web:
       bash /entrypoint.sh -F &
       PID=$! ;
       echo sc4s_fallback,index,concourse >>/opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv ;
-      kill -SIGHUP $PID
+      kill -SIGHUP $PID ;
+      trap : TERM INT ;
+      tail -f /dev/null & wait
     ## See https://splunk-connect-for-syslog.readthedocs.io/en/master/gettingstarted/docker-systemd-general/#configure-the-sc4s-environment
     env:
     - name: SPLUNK_HEC_URL

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -686,7 +686,7 @@ concourse:
       - name: SPLUNK_HEC_URL
         value: https://http-inputs-opendoor.splunkcloud.com:443
       - name: SPLUNK_HEC_TOKEN
-        value: od_secret:concourse/engineering/concourse-web/splunk_hec_token#value
+        value: od_secret:secret/kubernetes/concourse/concourse-web/splunk#hec_token
 
     auth:
       ## Force sending secure flag on http cookies


### PR DESCRIPTION
We'd like to get Concourse build logs into Splunk so we can make dashboards for common infra errors. The cleanest way to get build logs from Concourse is to use their [syslog integration](https://github.com/concourse/concourse/issues/2104#issuecomment-418421166). This PR adds a sidecar to the Concourse deployment that runs a [Syslog to Splunk container](https://splunkbase.splunk.com/app/4740/). Concourse will send the logs to it, and it will send them to Splunk.

Testing:
- [x] Test against Concourse manual.